### PR TITLE
Make sxCompose generinc

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,7 @@
 import { SxProps, Theme } from "@mui/system";
-declare type ISxPropsType = SxProps<Theme>;
-interface ICombineMuiSx {
+interface ICombineMuiSx<T extends Theme> {
     condition: boolean;
-    sx: ISxPropsType;
+    sx: SxProps<T>;
 }
-declare const sxCompose: (...sx: Array<ICombineMuiSx | ISxPropsType>) => ISxPropsType;
+declare const sxCompose: (...sx: Array<ICombineMuiSx | SxProps<T>>) => SxProps<T>;
 export default sxCompose;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,5 +3,5 @@ interface ICombineMuiSx<T extends Theme> {
     condition: boolean;
     sx: SxProps<T>;
 }
-declare const sxCompose: (...sx: Array<ICombineMuiSx | SxProps<T>>) => SxProps<T>;
+declare const sxCompose: <T extends Theme>(...sx: Array<ICombineMuiSx | SxProps<T>>) => SxProps<T>;
 export default sxCompose;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,18 @@
 import { SxProps, Theme } from "@mui/system";
 
-type ISxPropsType = SxProps<Theme>;
-
-interface ICombineMuiSx {
-  condition: boolean;
-  sx: ISxPropsType;
+interface ICombineMuiSx<T extends Theme> {
+  condition: boolean
+  sx: SxProps<T>
 }
 
-const sxCompose = (
-    ...sx: Array<ICombineMuiSx | ISxPropsType>
-  ): ISxPropsType => {
-    return sx.reduce((acc: ISxPropsType, curr: ICombineMuiSx | ISxPropsType) => {
-      if ((curr as ICombineMuiSx).condition) {
-        return { ...acc, ...(curr as ICombineMuiSx).sx } as ISxPropsType;
-      }
-      return { ...acc, ...(curr as ISxPropsType) } as ISxPropsType;
-    }, {} as ISxPropsType);
-  };
+
+const sxCompose = <T extends Theme>(...sx: Array<ICombineMuiSx<T> | SxProps<T>>): SxProps<T> => {
+  return sx.reduce((acc: SxProps<T>, curr: ICombineMuiSx<T> | SxProps<T>) => {
+    if ((curr as ICombineMuiSx<T>).condition) {
+      return { ...acc, ...(curr as ICombineMuiSx<T>).sx } as SxProps
+    }
+    return { ...acc, ...(curr as SxProps<T>) } as SxProps
+  }, {} as SxProps)
+}
 
 export default sxCompose


### PR DESCRIPTION
mui-sx relies on the default theme, and therefore the types won't match if you have defined a custom theme.
By making xsCompose generic, the custom theme is injected via the MUI provider context, and this will no longer be an issue.